### PR TITLE
Set diamonds as fixed trump suit

### DIFF
--- a/rlohhell/games/ohhell/dealer.py
+++ b/rlohhell/games/ohhell/dealer.py
@@ -1,4 +1,5 @@
 from rlohhell.utils.utils import init_short_deck
+from rlohhell.games.base import Card
 
 class OhHellDealer:
 
@@ -16,13 +17,18 @@ class OhHellDealer:
         self.np_random.shuffle(self.deck)
 
     def flip_trump_card(self):
-        ''' Flip trump card when a new game starts
+        """Return the trump card for a new game.
+
+        The original implementation flipped a random card from the deck to
+        determine the trump suit. In this variant the trump suit is fixed to
+        diamonds, so we simply return a diamond card without altering the deck.
 
         Returns:
-            (object): The card to be used as the trump card 
-        '''
-        trump_card = self.deck.pop()
-        return trump_card
+            Card: A :class:`Card` object representing the trump. The rank is
+            irrelevant for trump determination, so the lowest rank is used.
+        """
+        # Always return a diamond card
+        return Card('D', '6')
 
     def deal_cards(self, player, num):
         ''' Deal some cards from deck to one player

--- a/tests/games/test_ohhell_game.py
+++ b/tests/games/test_ohhell_game.py
@@ -80,6 +80,17 @@ class TestOhHellMethods(unittest.TestCase):
         winner = determine_winner(played_cards, trump_card)
         self.assertEqual(winner, 0)
 
+    def test_trump_always_diamonds(self):
+        """Ensure diamonds are always treated as the trump suit."""
+        game = Game()
+        game.init_game()
+        self.assertEqual(game.trump_card.suit, 'D')
+
+        # A diamond should beat a non-diamond card of the same rank.
+        played_cards = [Card('D', '9'), Card('H', '9')]
+        winner = determine_winner(played_cards, game.trump_card)
+        self.assertEqual(winner, 0)
+
     def test_player_get_player_id(self):
         player = Player(0, np.random.RandomState())
         self.assertEqual(0, player.get_player_id())


### PR DESCRIPTION
## Summary
- Always return a diamond card as the trump suit without modifying the deck
- Test that games consistently use diamonds as the trump suit

## Testing
- `pytest tests/games tests/utils -q`
- `python - <<'PY'
from rlohhell.games.ohhell.game import OhHellGame as Game
from rlohhell.games.base import Card
from rlohhell.games.ohhell.utils import determine_winner

game = Game()
game.init_game()
print('Trump suit:', game.trump_card.suit)
played_cards = [Card('D','9'), Card('H','9')]
winner = determine_winner(played_cards, game.trump_card)
print('Winner index:', winner)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1a8e67d9883299ada2ec50db3e743