### PR TITLE
Fix trump suit to diamonds

### DIFF
--- a/rlohhell/games/ohhell/dealer.py
+++ b/rlohhell/games/ohhell/dealer.py
@@ -1,4 +1,5 @@
 from rlohhell.utils.utils import init_short_deck
+from rlohhell.games.ohhell.utils import get_fixed_trump_card
 
 class OhHellDealer:
 
@@ -19,10 +20,9 @@ class OhHellDealer:
         ''' Flip trump card when a new game starts
 
         Returns:
-            (object): The card to be used as the trump card 
+            (object): The card to be used as the trump card
         '''
-        trump_card = self.deck.pop()
-        return trump_card
+        return get_fixed_trump_card()
 
     def deal_cards(self, player, num):
         ''' Deal some cards from deck to one player

--- a/rlohhell/games/ohhell/game.py
+++ b/rlohhell/games/ohhell/game.py
@@ -111,11 +111,8 @@ class OhHellGame:
         for i in range(num_cards * self.num_players):
             self.players[i % self.num_players].hand.append(self.dealer.deal_card())
 
-        # If the deck is exhausted there is no trump card this round
-        if len(self.dealer.deck) > 0:
-            self.trump_card = self.dealer.flip_trump_card()
-        else:
-            self.trump_card = None
+        # Diamonds are always trump in this variant
+        self.trump_card = self.dealer.flip_trump_card()
         self.played_cards = []
         self.round = Round(
             round_number=num_cards,

--- a/rlohhell/games/ohhell/utils.py
+++ b/rlohhell/games/ohhell/utils.py
@@ -8,6 +8,9 @@ import rlohhell
 from rlohhell.utils.utils import rank2int, int2rank
 from rlohhell.games.base import Card
 
+# In this variant diamonds are always trump
+TRUMP_SUIT = 'D'
+
 # Read required docs
 ROOT_PATH = rlohhell.__path__[0]
 
@@ -42,11 +45,12 @@ def determine_winner(played_cards, trump_card):
     '''
     Return the index of the player that wins in that round
 
-    trump_card (Card): A list of just one card 
+    trump_card (Card): A list of just one card. The suit of this card is
+        ignored because diamonds are always trump in this variant.
     played_cards (list): A list of cards played in the round so far
     '''
 
-    trump_suit = trump_card.suit if trump_card is not None else None
+    trump_suit = TRUMP_SUIT
     first_suit = played_cards[0].suit
 
     if trump_suit is not None:
@@ -85,5 +89,10 @@ def trumps_in_hand(hand, trump_suit):
     ''' Return an array with the trumps from a given list'''
     trump_cards = [ card for card in hand if trump_suit == card.suit ]
     return trump_cards
+
+
+def get_fixed_trump_card():
+    '''Return the fixed trump card for this variant.'''
+    return Card(TRUMP_SUIT, 'A')
 
 

--- a/tests/test_trump_suit.py
+++ b/tests/test_trump_suit.py
@@ -1,0 +1,21 @@
+import pytest
+
+from rlohhell.games.base import Card
+from rlohhell.games.ohhell.game import OhHellGame
+from rlohhell.games.ohhell.utils import determine_winner, TRUMP_SUIT
+
+
+def test_game_always_sets_diamond_trump():
+    game = OhHellGame()
+    game.init_game()
+
+    assert game.trump_card.suit == TRUMP_SUIT
+
+
+def test_diamond_card_wins_against_same_rank_other_suit():
+    played_cards = [Card('D', '9'), Card('H', '9')]
+
+    # Passing a non-diamond trump_card should not affect the outcome
+    winner = determine_winner(played_cards, Card('S', 'A'))
+
+    assert winner == 0


### PR DESCRIPTION
## Summary
- set diamonds as the permanent trump suit and provide a helper for the fixed trump card
- update round setup to always use the fixed trump card
- add tests confirming the diamond trump is used and wins against equal-ranked cards

## Testing
- python -m pytest tests/test_trump_suit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695247912c1c8329aef4e525b83495ab)