### PR TITLE
Implement Oh Hell round scoring

### DIFF
--- a/rlohhell/games/ohhell/judger.py
+++ b/rlohhell/games/ohhell/judger.py
@@ -23,16 +23,32 @@ class OhHellJudger:
 
 
     def judge_game(self, players):
-        ''' Return the winner of the game
+        '''Calculate round scores according to Oh Hell rules.
+
+        A player scores ``10 * bid`` points for matching their bid exactly.
+        If they win more tricks than they bid they receive a consolation equal
+        to the number of tricks taken.  Missing the bid on the low side costs
+        ``10 * bid`` points.
 
         Args:
             players (list): The list of players who play the game
+        Returns:
+            tuple: Round scores for each player in order
         '''
 
+        round_scores = []
+
         for player in players:
-            if player.tricks_won == player.proposed_tricks:
-                player.tricks_won += 10
+            bid = player.proposed_tricks
+            tricks = player.tricks_won
 
-        final_scores = [player.tricks_won for player in players]
+            if tricks == bid:
+                score = 10 * bid
+            elif tricks > bid:
+                score = tricks
+            else:
+                score = -10 * bid
 
-        return tuple(final_scores)
+            round_scores.append(score)
+
+        return tuple(round_scores)

--- a/tests/games/test_scoring_rules.py
+++ b/tests/games/test_scoring_rules.py
@@ -1,0 +1,23 @@
+from rlohhell.games.ohhell.judger import OhHellJudger as Judger
+from rlohhell.games.ohhell.player import OhHellPlayer as Player
+
+
+def test_round_scoring_matches_examples():
+    rng = None
+    players = [Player(i, rng) for i in range(3)]
+
+    players[0].proposed_tricks = 2
+    players[0].tricks_won = 2
+
+    players[1].proposed_tricks = 3
+    players[1].tricks_won = 1
+
+    players[2].proposed_tricks = 1
+    players[2].tricks_won = 2
+
+    scores = Judger(rng).judge_game(players)
+
+    assert scores == (20, -30, 2)
+    assert players[0].tricks_won == 2
+    assert players[1].tricks_won == 1
+    assert players[2].tricks_won == 2


### PR DESCRIPTION
## Summary
- implement Oh Hell round scoring that awards bids, consolation for overtricks, and penalties for underbids
- add a unit test covering the provided scoring examples to guard the calculation

## Testing
- pytest tests/games/test_scoring_rules.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695250d3fe28832993adaa407357351c)