### PR TITLE
Add action masks and masking tests for Gym env

### DIFF
--- a/tests/envs/test_action_masks.py
+++ b/tests/envs/test_action_masks.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from rlohhell.envs.ohhell import OhHellEnv2, mask_from_state
+from rlohhell.games.base import Card
+
+
+def test_mask_prevents_illegal_last_bid():
+    env = OhHellEnv2(num_players=3, agent_id=2)
+    env.reset()
+
+    game = env.game
+    round_state = game.round
+    round_state.round_number = 3
+    round_state.players_proposed = game.num_players - 1
+    round_state.proposed_tricks = [1, 1, 0]
+    round_state.current_player = env.agent_id
+
+    for idx, player in enumerate(game.players):
+        player.has_proposed = idx < game.num_players - 1
+        player.proposed_tricks = round_state.proposed_tricks[idx]
+        player.hand = [Card("S", "6"), Card("H", "6"), Card("D", "6")]
+
+    state = game.get_state(env.agent_id)
+    mask = mask_from_state(state)
+
+    assert mask.dtype == np.bool_
+    assert mask.shape == (len(game.players[env.agent_id].hand) + 1,)
+    assert bool(mask[1]) is False
+    assert mask.sum() == mask.size - 1
+
+
+def test_mask_enforces_following_suit_and_joker_modes():
+    env = OhHellEnv2(num_players=2, agent_id=0)
+    env.reset()
+
+    game = env.game
+    round_state = game.round
+    round_state.round_number = 3
+    round_state.players_proposed = game.num_players
+    round_state.current_player = env.agent_id
+    round_state.last_winner = 1
+    round_state.played_cards = [Card("H", "9")]
+
+    player = game.players[env.agent_id]
+    player.has_proposed = True
+    player.hand = [Card("H", "6"), Card("S", "7"), Card("S", "6")]
+
+    state = game.get_state(env.agent_id)
+    mask = mask_from_state(state)
+
+    assert mask.dtype == np.bool_
+    assert mask.shape == (len(player.hand) + 2,)
+
+    assert bool(mask[0]) is True  # Follow suit with hearts
+    assert bool(mask[2]) is False  # Cannot slough off other suits while holding hearts
+    assert bool(mask[len(player.hand)]) is True  # 7♠ low option
+    assert bool(mask[len(player.hand) + 1]) is True  # 7♠ high option

--- a/tests/envs/test_ohhell_gym_env.py
+++ b/tests/envs/test_ohhell_gym_env.py
@@ -1,7 +1,10 @@
 import random
 
 import numpy as np
-from stable_baselines3 import PPO
+import pytest
+
+sb3 = pytest.importorskip("stable_baselines3")
+PPO = sb3.PPO
 
 from rlohhell.envs.ohhell import OhHellEnv2
 
@@ -11,13 +14,16 @@ def test_reset_and_step_returns_valid_shapes():
     obs, _ = env.reset()
     assert obs.shape == (env.obs_size,)
 
-    legal_actions = list(env._get_legal_actions())
+    action_mask = env._get_legal_actions()
+    legal_actions = list(action_mask)
     action = random.choice(legal_actions)
 
     next_obs, reward, terminated, truncated, info = env.step(action)
     assert next_obs.shape == (env.obs_size,)
     assert isinstance(reward, float)
     assert "legal_actions" in info
+    assert "action_mask" in info
+    assert info["action_mask"].dtype == np.bool_
     assert isinstance(terminated, bool)
     assert isinstance(truncated, bool)
 


### PR DESCRIPTION
## Summary
- add dynamic action masking utility for Oh Hell gym environment and expose masks via reset/step info
- align action decoding with new masking scheme and cap discrete action space
- add tests covering bidding/playing masks and ensure gym env returns masks

## Testing
- pytest tests/envs/test_action_masks.py tests/envs/test_ohhell_gym_env.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529cda3f8083299c621dc31361878f)