### PR TITLE
Fix mask length for vectorized training

### DIFF
--- a/tests/envs/test_action_masks.py
+++ b/tests/envs/test_action_masks.py
@@ -24,9 +24,10 @@ def test_mask_prevents_illegal_last_bid():
     mask = mask_from_state(state)
 
     assert mask.dtype == np.bool_
-    assert mask.shape == (len(game.players[env.agent_id].hand) + 1,)
+    assert mask.shape == (env.MAX_ACTIONS,)
     assert bool(mask[1]) is False
-    assert mask.sum() == mask.size - 1
+    allowed_bids = np.flatnonzero(mask[: len(game.players[env.agent_id].hand) + 1])
+    assert set(allowed_bids) == {0, 2, 3}
 
 
 def test_mask_enforces_following_suit_and_joker_modes():
@@ -49,7 +50,7 @@ def test_mask_enforces_following_suit_and_joker_modes():
     mask = mask_from_state(state)
 
     assert mask.dtype == np.bool_
-    assert mask.shape == (len(player.hand) + 2,)
+    assert mask.shape == (env.MAX_ACTIONS,)
 
     assert bool(mask[0]) is True  # Follow suit with hearts
     assert bool(mask[2]) is False  # Cannot slough off other suits while holding hearts

--- a/tests/envs/test_ohhell_gym_env.py
+++ b/tests/envs/test_ohhell_gym_env.py
@@ -40,3 +40,22 @@ def test_short_training_loop_executes():
     obs, _ = env.reset()
     action, _ = model.predict(obs, deterministic=True)
     assert not np.isnan(action)
+
+
+def test_action_mask_keeps_constant_shape_after_steps():
+    env = OhHellEnv2()
+    obs, info = env.reset()
+
+    mask = info["action_mask"]
+    assert mask.shape == (env.MAX_ACTIONS,)
+    assert env.action_masks().shape == (env.MAX_ACTIONS,)
+
+    for _ in range(5):
+        action = int(np.flatnonzero(mask)[0])
+        obs, _, terminated, _, info = env.step(action)
+        assert obs["action_mask"].shape == (env.MAX_ACTIONS,)
+        assert info["action_mask"].shape == (env.MAX_ACTIONS,)
+        assert env.action_masks().shape == (env.MAX_ACTIONS,)
+        mask = info["action_mask"]
+        if terminated:
+            break

--- a/tests/scripts/test_entropy_scheduler.py
+++ b/tests/scripts/test_entropy_scheduler.py
@@ -1,0 +1,33 @@
+import math
+
+import pytest
+
+sb3 = pytest.importorskip("stable_baselines3")
+from stable_baselines3.common.callbacks import CallbackList
+from stable_baselines3.common.env_util import make_vec_env
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from rlohhell.envs.ohhell import OhHellEnv2
+from scripts.train_maskable_self_play import EntropyScheduler
+
+sb3_contrib = pytest.importorskip("sb3_contrib")
+from sb3_contrib.ppo_mask import MaskablePPO
+
+
+def test_entropy_scheduler_updates_maskable_ent_coef():
+    env = make_vec_env(
+        lambda: OhHellEnv2(num_players=4, agent_id=0), n_envs=1, vec_env_cls=DummyVecEnv
+    )
+    scheduler = EntropyScheduler(start=0.02, end=0.0, total_timesteps=4)
+    model = MaskablePPO(
+        "MultiInputPolicy",
+        env,
+        ent_coef=0.02,
+        n_steps=1,
+        batch_size=1,
+        verbose=0,
+    )
+
+    model.learn(total_timesteps=4, callback=CallbackList([scheduler]))
+
+    assert math.isclose(model.ent_coef, 0.0, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- keep OhHellEnv2 action masks at a fixed length and expose them for maskable algorithms
- pad bidding and play masks while preserving joker handling and add action mask info to step/reset outputs
- update environment tests to assert constant mask shape through gameplay

## Testing
- `pytest tests/envs/test_action_masks.py tests/envs/test_ohhell_gym_env.py -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eff0616883299cf0ab3d7b3940e9)