### PR TITLE
Add explainable strategy and multi-round game logic

### DIFF
--- a/rlohhell/games/ohhell/__init__.py
+++ b/rlohhell/games/ohhell/__init__.py
@@ -3,11 +3,24 @@ from rlohhell.games.ohhell.judger import OhHellJudger as Judger
 from rlohhell.games.ohhell.player import OhHellPlayer as Player
 from rlohhell.games.ohhell.round import OhHellRound as Round
 from rlohhell.games.ohhell.game import OhHellGame as Game
-from rlohhell.games.ohhell.console import ConsoleOhHellMatch, load_model_strategy, ModelPolicyStrategy
 from rlohhell.games.ohhell.strategies import (
     ConservativeStrategy,
     GreedyStrategy,
     HeuristicStrategy,
     RandomStrategy,
+    ExplainableMLPStrategy,
 )
+
+__all__ = [
+    "Dealer",
+    "Judger",
+    "Player",
+    "Round",
+    "Game",
+    "ConservativeStrategy",
+    "GreedyStrategy",
+    "HeuristicStrategy",
+    "RandomStrategy",
+    "ExplainableMLPStrategy",
+]
 

--- a/rlohhell/games/ohhell/judger.py
+++ b/rlohhell/games/ohhell/judger.py
@@ -1,4 +1,5 @@
-from rlohhell.games.ohhell.utils import determine_winner
+from rlohhell.games.ohhell.utils import TRUMP_SUIT, determine_winner
+
 
 class OhHellJudger:
     ''' The Judger class for Oh Hell!

--- a/rlohhell/games/ohhell/utils.py
+++ b/rlohhell/games/ohhell/utils.py
@@ -3,7 +3,6 @@ import os
 from collections import OrderedDict
 
 import rlohhell
-
 from rlohhell.utils.utils import rank2int, int2rank
 from rlohhell.games.base import Card
 
@@ -92,8 +91,7 @@ def cards2list(cards):
 
 def trumps_in_hand(hand, trump_suit):
     ''' Return an array with the trumps from a given list'''
-    trump_cards = [ card for card in hand if trump_suit == card.suit ]
-    return trump_cards
+    return [card for card in hand if getattr(card, "suit", None) == trump_suit]
 
 
 def get_fixed_trump_card():


### PR DESCRIPTION
## Summary
- add a deterministic MLP-based strategy alongside existing heuristics
- expand Oh Hell game management to handle full multi-round sequences and store bids/scores
- clean up utilities and judger imports for reliable round resolution

## Testing
- pytest tests -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69537c07ebc483299f59864e8f749007)