### PR TITLE
Add student poker self-play option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,21 @@ PY
 During bidding you will be prompted for your bid; during play you will see your hand, the legal cards you can choose, and who wins each trick. If you set `record_history=True` (default) you can also inspect the in-memory log after the match.
 
 ## Training
-Use the self-play helper in `scripts/train_maskable_self_play.py` to train a MaskablePPO agent:
+Use the self-play helper in `scripts/train_maskable_self_play.py` to train a MaskablePPO agent or resume from a saved checkpoint:
 
 ```bash
 python scripts/train_maskable_self_play.py --help  # view options
 python scripts/train_maskable_self_play.py --total-timesteps 1_000_000 --num-envs 8
+python scripts/train_maskable_self_play.py --resume-from runs/maskable_ppo/checkpoints/maskable_ppo_100000_steps.zip
 ```
 
 Checkpoints and TensorBoard logs will be written under `runs/` (ignored by git). Saved models can be loaded with `load_model_strategy` for console play or evaluation.
+
+To train the custom `StudentPokerPolicy` backbone with the same self-play loop, enable the student flag:
+
+```bash
+python scripts/train_maskable_self_play.py --use-student-poker --total-timesteps 1_000_000
+```
 
 ## Running tests
 ```bash

--- a/rlohhell/envs/ohhell.py
+++ b/rlohhell/envs/ohhell.py
@@ -48,6 +48,8 @@ def mask_from_state(state, max_actions: int = MAX_ACTIONS):
         for bid in legal_actions:
             if 0 <= bid < max_actions:
                 mask[bid] = True
+        if not mask.any():
+            mask[0] = True
         return mask
 
     seven_spades = Card("S", "7")
@@ -73,6 +75,9 @@ def mask_from_state(state, max_actions: int = MAX_ACTIONS):
                 for action in legal_actions
             ):
                 mask[high_idx] = True
+
+    if not mask.any():
+        mask[0] = True
 
     return mask
 

--- a/rlohhell/policies/__init__.py
+++ b/rlohhell/policies/__init__.py
@@ -1,4 +1,7 @@
 from rlohhell.policies.maskable_lstm_policy import MaskableLstmPolicy
-from rlohhell.policies.student_poker_policy import StudentPokerPolicy
+from rlohhell.policies.student_poker_policy import (
+    StudentPokerActorCriticPolicy,
+    StudentPokerPolicy,
+)
 
-__all__ = ["StudentPokerPolicy", "MaskableLstmPolicy"]
+__all__ = ["StudentPokerPolicy", "MaskableLstmPolicy", "StudentPokerActorCriticPolicy"]

--- a/rlohhell/policies/student_poker_policy.py
+++ b/rlohhell/policies/student_poker_policy.py
@@ -171,10 +171,10 @@ class StudentPokerExtractor(BaseFeaturesExtractor):
             play_action_size=observation_space["action_mask"].shape[-1],
             hand_size=hand_size,
         )
-        self.student = model
         self.hand_size = hand_size
         self.trick_size = trick_size
         super().__init__(observation_space, features_dim=model.hidden_size)
+        self.student = model
 
     def forward(self, observations: Dict[str, torch.Tensor]) -> torch.Tensor:  # type: ignore[override]
         flat = torch.as_tensor(observations["observation"], dtype=torch.float32)

--- a/rlohhell/policies/student_poker_policy.py
+++ b/rlohhell/policies/student_poker_policy.py
@@ -1,7 +1,12 @@
 from typing import Dict, Optional, Tuple, Union
 
+import numpy as np
 import torch
 import torch.nn as nn
+
+from gymnasium import spaces
+from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 
 
 class StudentPokerPolicy(nn.Module):
@@ -53,14 +58,22 @@ class StudentPokerPolicy(nn.Module):
             state.
         """
 
-        features = self._encode_observation(obs)
-        lstm_input = torch.relu(self.input_projection(features)).unsqueeze(1)
-        lstm_output, next_state = self.lstm(lstm_input, hidden_state)
-        body = lstm_output[:, -1, :]
+        body, next_state = self.encode_body(obs, hidden_state=hidden_state)
 
         logits = self._select_head(body, phase)
         logits = self._apply_mask(logits, action_mask)
         return logits, next_state
+
+    def encode_body(
+        self,
+        obs: Dict[str, Union[torch.Tensor, "numpy.ndarray"]],
+        hidden_state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        features = self._encode_observation(obs)
+        lstm_input = torch.relu(self.input_projection(features)).unsqueeze(1)
+        lstm_output, next_state = self.lstm(lstm_input, hidden_state)
+        body = lstm_output[:, -1, :]
+        return body, next_state
 
     def value(
         self,
@@ -125,3 +138,76 @@ class StudentPokerPolicy(nn.Module):
                 "Action mask must have the same shape as the output logits."
             )
         return logits.masked_fill(~bool_mask, -1e9)
+
+
+def _split_student_observation(flat: torch.Tensor, hand_size: int, trick_size: int) -> Dict[str, torch.Tensor]:
+    hand = flat[..., :hand_size]
+    trick = flat[..., hand_size : hand_size + trick_size]
+    public_state = flat[..., hand_size + trick_size :]
+    return {
+        "hand": hand,
+        "trick": trick,
+        "public_state": public_state,
+    }
+
+
+class StudentPokerExtractor(BaseFeaturesExtractor):
+    """Feature extractor that reuses :class:`StudentPokerPolicy`'s body."""
+
+    def __init__(
+        self,
+        observation_space: spaces.Dict,
+        base_model: Optional[StudentPokerPolicy] = None,
+        hand_size: int = 36,
+        trick_size: int = 36,
+        public_state_dim: Optional[int] = None,
+    ) -> None:
+        obs_size = int(np.prod(observation_space["observation"].shape))
+        inferred_public_dim = public_state_dim or max(1, obs_size - hand_size - trick_size)
+        model = base_model or StudentPokerPolicy(
+            public_state_dim=inferred_public_dim,
+            trick_embedding_dim=trick_size,
+            bid_action_size=observation_space["action_mask"].shape[-1],
+            play_action_size=observation_space["action_mask"].shape[-1],
+            hand_size=hand_size,
+        )
+        self.student = model
+        self.hand_size = hand_size
+        self.trick_size = trick_size
+        super().__init__(observation_space, features_dim=model.hidden_size)
+
+    def forward(self, observations: Dict[str, torch.Tensor]) -> torch.Tensor:  # type: ignore[override]
+        flat = torch.as_tensor(observations["observation"], dtype=torch.float32)
+        obs_dict = _split_student_observation(flat, self.hand_size, self.trick_size)
+        body, _ = self.student.encode_body(obs_dict)
+        return body
+
+
+class IdentityMlpExtractor(nn.Module):
+    """Bypass extractor that forwards latent features to policy and value heads."""
+
+    def __init__(self, latent_dim: int) -> None:
+        super().__init__()
+        self.latent_dim_pi = latent_dim
+        self.latent_dim_vf = latent_dim
+
+    def forward(self, features: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return features, features
+
+
+class StudentPokerActorCriticPolicy(MaskableActorCriticPolicy):
+    """Maskable PPO policy that swaps in the StudentPoker recurrent backbone."""
+
+    def __init__(self, observation_space: spaces.Dict, action_space: spaces.Discrete, lr_schedule, **kwargs):
+        self._student_extractor: Optional[StudentPokerExtractor] = None
+        super().__init__(
+            observation_space,
+            action_space,
+            lr_schedule,
+            features_extractor_class=StudentPokerExtractor,
+            **kwargs,
+        )
+
+    def _build_mlp_extractor(self) -> None:
+        self.mlp_extractor = IdentityMlpExtractor(self.features_dim)
+

--- a/scripts/train_student_poker_policy.py
+++ b/scripts/train_student_poker_policy.py
@@ -1,0 +1,246 @@
+"""Supervised training pipeline for :class:`StudentPokerPolicy`.
+
+This script collects trajectories from the existing heuristic bot and trains a
+two-headed recurrent policy to imitate its bidding and play decisions. The
+pipeline is intentionally lightweight and relies only on PyTorch plus the
+existing Oh Hell environment. Collected samples are split into bidding and play
+phases so that the appropriate policy head is optimised with cross-entropy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Literal, Sequence
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+from tqdm import trange
+
+from rlohhell.envs.ohhell import OhHellEnv2
+from rlohhell.policies import StudentPokerPolicy
+from rlohhell.utils.opponents import StrategyOpponent
+from rlohhell.games.ohhell.strategies import HeuristicStrategy
+
+
+Phase = Literal["bid", "play"]
+
+
+@dataclass
+class StudentSample:
+    """Single observation-action pair for StudentPokerPolicy training."""
+
+    hand: torch.Tensor
+    public_state: torch.Tensor
+    trick: torch.Tensor
+    action: int
+    mask: torch.Tensor
+    phase: Phase
+
+
+class StudentDataset(Dataset[StudentSample]):
+    """Dataset of StudentPokerPolicy experiences."""
+
+    def __init__(self, samples: Sequence[StudentSample]):
+        self.samples = list(samples)
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> StudentSample:
+        return self.samples[idx]
+
+
+def collate_batch(batch: Sequence[StudentSample]) -> Dict[str, torch.Tensor]:
+    hands = torch.stack([sample.hand for sample in batch])
+    public_state = torch.stack([sample.public_state for sample in batch])
+    trick = torch.stack([sample.trick for sample in batch])
+    actions = torch.tensor([sample.action for sample in batch], dtype=torch.long)
+    masks = torch.stack([sample.mask for sample in batch])
+    phases = [sample.phase for sample in batch]
+    return {
+        "hand": hands,
+        "public_state": public_state,
+        "trick": trick,
+        "action": actions,
+        "mask": masks,
+        "phase": phases,
+    }
+
+
+def split_phase_indices(phases: Sequence[Phase]) -> Dict[Phase, List[int]]:
+    indices = {"bid": [], "play": []}
+    for idx, phase in enumerate(phases):
+        indices[phase].append(idx)
+    return indices
+
+
+def select_subset(obs_dict: Dict[str, torch.Tensor], indices: Iterable[int]) -> Dict[str, torch.Tensor]:
+    idx_tensor = torch.tensor(list(indices), dtype=torch.long)
+    return {key: value.index_select(0, idx_tensor) for key, value in obs_dict.items()}
+
+
+def determine_phase(state) -> Phase:
+    legal = state.get("legal_actions", [])
+    if legal and isinstance(legal[0], int):
+        return "bid"
+    return "play"
+
+
+def action_id_from_teacher(choice, env: OhHellEnv2, state, action_mask) -> int:
+    legal_positions = [idx for idx, allowed in enumerate(action_mask) if allowed]
+    if not legal_positions:
+        raise ValueError("Teacher was asked to act with no legal actions available")
+
+    def _matches(decoded, target) -> bool:
+        if isinstance(target, int) and isinstance(decoded, int):
+            return decoded == target
+        return decoded == target
+
+    for pos in legal_positions:
+        decoded = env._decode_action(int(pos), state)
+        if _matches(decoded, choice):
+            return int(pos)
+
+    return int(legal_positions[0])
+
+
+def extract_student_obs(obs: Dict[str, torch.Tensor], action_mask) -> Dict[str, torch.Tensor]:
+    observation = torch.as_tensor(obs["observation"], dtype=torch.float32)
+    hand_size = 36
+    trick_size = 36
+    hand = observation[:hand_size]
+    trick = observation[hand_size : hand_size + trick_size]
+    public_state = observation[hand_size + trick_size :]
+    mask = torch.as_tensor(action_mask, dtype=torch.float32)
+    return {"hand": hand, "public_state": public_state, "trick": trick, "mask": mask}
+
+
+def collect_dataset(episodes: int, seed: int) -> List[StudentSample]:
+    env = OhHellEnv2(opponent_policy=None)
+    teacher = StrategyOpponent("teacher", HeuristicStrategy())
+    samples: List[StudentSample] = []
+
+    for episode in trange(episodes, desc="Collecting episodes"):
+        obs, info = env.reset(seed=seed + episode)
+        done = False
+
+        while not done:
+            state = env.game.get_state(env.agent_id)
+            phase: Phase = determine_phase(state)
+            teacher_choice = teacher.act(state, info["action_mask"], obs, env.game)
+            action_id = action_id_from_teacher(teacher_choice, env, state, info["action_mask"])
+
+            student_obs = extract_student_obs(obs, info["action_mask"])
+            samples.append(
+                StudentSample(
+                    hand=student_obs["hand"],
+                    public_state=student_obs["public_state"],
+                    trick=student_obs["trick"],
+                    action=action_id,
+                    mask=student_obs["mask"],
+                    phase=phase,
+                )
+            )
+
+            obs, _, done, _, info = env.step(action_id)
+
+    return samples
+
+
+def train(
+    dataset: StudentDataset,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    device: str,
+    save_path: str,
+) -> None:
+    if len(dataset) == 0:
+        raise ValueError("Cannot train StudentPokerPolicy on an empty dataset")
+
+    sample = dataset[0]
+    model = StudentPokerPolicy(
+        public_state_dim=sample.public_state.shape[-1],
+        trick_embedding_dim=sample.trick.shape[-1],
+        bid_action_size=sample.mask.shape[-1],
+        play_action_size=sample.mask.shape[-1],
+        hand_size=sample.hand.shape[-1],
+    ).to(device)
+    optimiser = torch.optim.Adam(model.parameters(), lr=lr)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=collate_batch)
+
+    for epoch in trange(epochs, desc="Training"):
+        epoch_loss = 0.0
+        for batch in dataloader:
+            observations = {
+                "hand": batch["hand"].to(device),
+                "public_state": batch["public_state"].to(device),
+                "trick": batch["trick"].to(device),
+            }
+            masks = batch["mask"].to(device)
+            actions = batch["action"].to(device)
+            phases: List[Phase] = batch["phase"]
+            phase_indices = split_phase_indices(phases)
+
+            loss = torch.tensor(0.0, device=device)
+
+            if phase_indices["bid"]:
+                subset = select_subset(observations, phase_indices["bid"])
+                bid_actions = actions.index_select(0, torch.tensor(phase_indices["bid"], device=device))
+                bid_masks = masks.index_select(0, torch.tensor(phase_indices["bid"], device=device))
+                logits, _ = model(subset, phase="bid", action_mask=bid_masks)
+                loss = loss + nn.functional.cross_entropy(logits, bid_actions)
+
+            if phase_indices["play"]:
+                subset = select_subset(observations, phase_indices["play"])
+                play_actions = actions.index_select(0, torch.tensor(phase_indices["play"], device=device))
+                play_masks = masks.index_select(0, torch.tensor(phase_indices["play"], device=device))
+                logits, _ = model(subset, phase="play", action_mask=play_masks)
+                loss = loss + nn.functional.cross_entropy(logits, play_actions)
+
+            optimiser.zero_grad()
+            loss.backward()
+            optimiser.step()
+            epoch_loss += float(loss.detach().cpu())
+
+        print(f"Epoch {epoch + 1}: loss={epoch_loss / max(1, len(dataloader)):.4f}")
+
+    os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+    torch.save(model.state_dict(), save_path)
+    print(f"Saved StudentPokerPolicy to {save_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train StudentPokerPolicy via imitation")
+    parser.add_argument("--episodes", type=int, default=100, help="Number of episodes to collect")
+    parser.add_argument("--epochs", type=int, default=10, help="Training epochs")
+    parser.add_argument("--batch-size", type=int, default=64, help="Batch size for optimisation")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument(
+        "--save-path", type=str, default="./runs/student_poker_policy.pt", help="Destination for the trained weights"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for data collection")
+    parser.add_argument("--device", type=str, default="cpu", help="Torch device")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    samples = collect_dataset(episodes=args.episodes, seed=args.seed)
+    dataset = StudentDataset(samples)
+    train(
+        dataset=dataset,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        device=args.device,
+        save_path=args.save_path,
+    )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a MaskablePPO-compatible StudentPoker policy backbone and feature extractor
- allow train_maskable_self_play to train the student model via a new flag and document the workflow

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b68c05148329891ba141b7411de3)