### PR TITLE
Add hall of fame utilities for opponent coevolution

### DIFF
--- a/rlohhell/evo/__init__.py
+++ b/rlohhell/evo/__init__.py
@@ -1,5 +1,14 @@
 """Evolutionary evaluation utilities."""
 
 from .eval_core import build_env_fn, evaluate_theta, fixed_seeds, play_episode
+from .hof import HallOfFame, mix_opponents, theta_opponent
 
-__all__ = ["build_env_fn", "evaluate_theta", "fixed_seeds", "play_episode"]
+__all__ = [
+    "HallOfFame",
+    "build_env_fn",
+    "evaluate_theta",
+    "fixed_seeds",
+    "mix_opponents",
+    "play_episode",
+    "theta_opponent",
+]

--- a/rlohhell/evo/hof.py
+++ b/rlohhell/evo/hof.py
@@ -1,0 +1,82 @@
+"""Hall of Fame utilities for opponent co-evolution."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from dataclasses import asdict, is_dataclass
+from typing import List, Sequence, Tuple
+
+from rlohhell.heuristics.param_bot import ParamVector
+from rlohhell.utils.opponents import OpponentPolicy, make_param_opponent
+
+
+class HallOfFame:
+    """Archive of top-performing parameter vectors."""
+
+    def __init__(self) -> None:
+        self.entries: List[Tuple[ParamVector, float, int]] = []
+
+    def add(self, theta: ParamVector, score: float, step: int) -> None:
+        """Add a candidate to the archive, keeping it sorted by score."""
+
+        self.entries.append((theta, score, step))
+        self.entries.sort(key=lambda item: item[1], reverse=True)
+
+    def top(self, k: int) -> List[Tuple[ParamVector, float, int]]:
+        """Return the ``k`` highest-scoring entries."""
+
+        return self.entries[:k]
+
+    def save(self, path: str) -> None:
+        """Persist the archive to ``path`` in JSON format."""
+
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        serialised = [
+            {
+                "theta": asdict(theta) if is_dataclass(theta) else dict(theta),
+                "score": score,
+                "step": step,
+            }
+            for theta, score, step in self.entries
+        ]
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(serialised, f)
+
+    @classmethod
+    def load(cls, path: str) -> "HallOfFame":
+        """Load an archive from ``path``."""
+
+        instance = cls()
+        if not os.path.exists(path):
+            return instance
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        for record in data:
+            theta = ParamVector(**record["theta"])
+            instance.add(theta, float(record["score"]), int(record["step"]))
+        return instance
+
+
+def theta_opponent(theta: ParamVector, name: str) -> OpponentPolicy:
+    """Wrap a :class:`ParamVector` into an :class:`OpponentPolicy`."""
+
+    return make_param_opponent(theta, name=name)
+
+
+def mix_opponents(
+    hof: HallOfFame, builtin: Sequence[OpponentPolicy], k: int
+) -> List[OpponentPolicy]:
+    """Combine base opponents with a random sample from the hall of fame."""
+
+    opponents = list(builtin)
+    candidates = hof.top(k)
+    if candidates:
+        sample = random.sample(candidates, k=min(k, len(candidates)))
+        opponents.extend(
+            theta_opponent(theta, name=f"hof_{step}") for theta, _score, step in sample
+        )
+    return opponents


### PR DESCRIPTION
## Summary
- add a hall of fame archive for storing, loading, and retrieving top parameter vectors
- provide helpers to wrap hall-of-fame entries as opponents and mix them with builtin opponents
- export the new evolutionary utilities from the evo package

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e83b98fc832992dc9892d2c85542)